### PR TITLE
TMS-574: Fix pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 - TMS-421: Allow additional customization from child theme
-- TMS-574: Fix materials page pagination.
+- TMS-574: Fix materials page pagination. #54
 
 ## [1.7.0] - 2021-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 - TMS-421: Allow additional customization from child theme
+- TMS-574: Fix materials page pagination.
 
 ## [1.7.0] - 2021-11-30
 

--- a/src/Models/page-materials.php
+++ b/src/Models/page-materials.php
@@ -183,7 +183,6 @@ class PageMaterials extends BaseModel {
             'post_type'      => Material::SLUG,
             'posts_per_page' => $per_page,
             'offset'         => ( $paged - 1 ) * $per_page,
-            'fields'         => 'ids',
         ];
 
         $selected_materials = get_field( 'materials' );

--- a/src/Models/page-materials.php
+++ b/src/Models/page-materials.php
@@ -211,7 +211,7 @@ class PageMaterials extends BaseModel {
 
         $this->setup_pagination( $per_page, $paged, $wp_query->found_posts );
 
-        return $wp_query->get_posts();
+        return $wp_query->posts;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `fields => ids` from materials query, which results in query object found_posts count displaying as 0, resulting in broken pagination.

## Motivation and Context
TMS-574

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)